### PR TITLE
Add basic book exchange API

### DIFF
--- a/appBookExchange/build.gradle.kts
+++ b/appBookExchange/build.gradle.kts
@@ -18,9 +18,15 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+        implementation("org.springframework.boot:spring-boot-starter")
+        implementation("org.springframework.boot:spring-boot-starter-web")
+        implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+        implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0")
+        runtimeOnly("org.postgresql:postgresql")
+        runtimeOnly("com.h2database:h2")
+
+        testImplementation("org.springframework.boot:spring-boot-starter-test")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 tasks.withType<Test> {

--- a/appBookExchange/src/main/java/com/example/bookexchange/BookExchangeApplication.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/BookExchangeApplication.java
@@ -1,13 +1,13 @@
-package com.example.demo;
+package com.example.bookexchange;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
-public class DemoApplication {
+public class BookExchangeApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(DemoApplication.class, args);
+		SpringApplication.run(BookExchangeApplication.class, args);
 	}
 
 }

--- a/appBookExchange/src/main/java/com/example/bookexchange/controller/BookController.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/controller/BookController.java
@@ -1,0 +1,36 @@
+package com.example.bookexchange.controller;
+
+import com.example.bookexchange.dto.BookDto;
+import com.example.bookexchange.dto.CreateBookRequest;
+import com.example.bookexchange.service.BookService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/books")
+@Tag(name = "Books")
+public class BookController {
+    private final BookService bookService;
+
+    public BookController(BookService bookService) {
+        this.bookService = bookService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Add book")
+    public BookDto add(@Validated @RequestBody CreateBookRequest request) {
+        return bookService.addBook(request);
+    }
+
+    @GetMapping
+    @Operation(summary = "List books")
+    public List<BookDto> list(@RequestParam(required = false) Long ownerId) {
+        return bookService.getBooks(ownerId);
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/controller/TradeController.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/controller/TradeController.java
@@ -1,0 +1,36 @@
+package com.example.bookexchange.controller;
+
+import com.example.bookexchange.dto.CreateTradeRequest;
+import com.example.bookexchange.dto.TradeDto;
+import com.example.bookexchange.service.TradeService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/trades")
+@Tag(name = "Trades")
+public class TradeController {
+    private final TradeService tradeService;
+
+    public TradeController(TradeService tradeService) {
+        this.tradeService = tradeService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Make trade")
+    public TradeDto trade(@Validated @RequestBody CreateTradeRequest request) {
+        return tradeService.makeTrade(request);
+    }
+
+    @GetMapping
+    @Operation(summary = "List trades")
+    public List<TradeDto> list() {
+        return tradeService.getTrades();
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/controller/UserController.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/controller/UserController.java
@@ -1,0 +1,36 @@
+package com.example.bookexchange.controller;
+
+import com.example.bookexchange.dto.CreateUserRequest;
+import com.example.bookexchange.dto.UserDto;
+import com.example.bookexchange.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/users")
+@Tag(name = "Users")
+public class UserController {
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Create user")
+    public UserDto create(@Validated @RequestBody CreateUserRequest request) {
+        return userService.createUser(request);
+    }
+
+    @GetMapping
+    @Operation(summary = "List users")
+    public List<UserDto> list() {
+        return userService.getUsers();
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/BookDto.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/BookDto.java
@@ -1,0 +1,3 @@
+package com.example.bookexchange.dto;
+
+public record BookDto(Long id, String title, String author, Long ownerId) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateBookRequest.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateBookRequest.java
@@ -1,0 +1,6 @@
+package com.example.bookexchange.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateBookRequest(@NotBlank String title, @NotBlank String author, @NotNull Long ownerId) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateTradeRequest.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateTradeRequest.java
@@ -1,0 +1,5 @@
+package com.example.bookexchange.dto;
+
+import jakarta.validation.constraints.NotNull;
+
+public record CreateTradeRequest(@NotNull Long offeredBookId, @NotNull Long requestedBookId) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateUserRequest.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/CreateUserRequest.java
@@ -1,0 +1,5 @@
+package com.example.bookexchange.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateUserRequest(@NotBlank String name) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/TradeDto.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/TradeDto.java
@@ -1,0 +1,5 @@
+package com.example.bookexchange.dto;
+
+import java.time.LocalDateTime;
+
+public record TradeDto(Long id, BookDto offeredBook, BookDto requestedBook, LocalDateTime tradedAt) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/dto/UserDto.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/dto/UserDto.java
@@ -1,0 +1,5 @@
+package com.example.bookexchange.dto;
+
+import java.util.List;
+
+public record UserDto(Long id, String name, List<BookDto> books) {}

--- a/appBookExchange/src/main/java/com/example/bookexchange/model/Book.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/model/Book.java
@@ -1,0 +1,53 @@
+package com.example.bookexchange.model;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Book {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+    private String author;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User owner;
+
+    public Book() {
+    }
+
+    public Book(String title, String author, User owner) {
+        this.title = title;
+        this.author = author;
+        this.owner = owner;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public User getOwner() {
+        return owner;
+    }
+
+    public void setOwner(User owner) {
+        this.owner = owner;
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/model/Trade.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/model/Trade.java
@@ -1,0 +1,43 @@
+package com.example.bookexchange.model;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+public class Trade {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    private Book offeredBook;
+
+    @ManyToOne
+    private Book requestedBook;
+
+    private LocalDateTime tradedAt = LocalDateTime.now();
+
+    public Trade() {
+    }
+
+    public Trade(Book offeredBook, Book requestedBook) {
+        this.offeredBook = offeredBook;
+        this.requestedBook = requestedBook;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Book getOfferedBook() {
+        return offeredBook;
+    }
+
+    public Book getRequestedBook() {
+        return requestedBook;
+    }
+
+    public LocalDateTime getTradedAt() {
+        return tradedAt;
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/model/User.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/model/User.java
@@ -1,0 +1,41 @@
+package com.example.bookexchange.model;
+
+import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name="users")
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Book> books = new ArrayList<>();
+
+    public User() {
+    }
+
+    public User(String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<Book> getBooks() {
+        return books;
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/repository/BookRepository.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/repository/BookRepository.java
@@ -1,0 +1,10 @@
+package com.example.bookexchange.repository;
+
+import com.example.bookexchange.model.Book;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface BookRepository extends JpaRepository<Book, Long> {
+    List<Book> findByOwnerId(Long ownerId);
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/repository/TradeRepository.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/repository/TradeRepository.java
@@ -1,0 +1,7 @@
+package com.example.bookexchange.repository;
+
+import com.example.bookexchange.model.Trade;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TradeRepository extends JpaRepository<Trade, Long> {
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/repository/UserRepository.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.example.bookexchange.repository;
+
+import com.example.bookexchange.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/service/BookService.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/service/BookService.java
@@ -1,0 +1,42 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.BookDto;
+import com.example.bookexchange.dto.CreateBookRequest;
+import com.example.bookexchange.model.Book;
+import com.example.bookexchange.model.User;
+import com.example.bookexchange.repository.BookRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class BookService {
+    private final BookRepository bookRepository;
+    private final UserService userService;
+
+    public BookService(BookRepository bookRepository, UserService userService) {
+        this.bookRepository = bookRepository;
+        this.userService = userService;
+    }
+
+    public BookDto addBook(CreateBookRequest request) {
+        User owner = userService.getUserById(request.ownerId());
+        Book book = new Book(request.title(), request.author(), owner);
+        bookRepository.save(book);
+        owner.getBooks().add(book);
+        return DtoMapper.toDto(book);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BookDto> getBooks(Long ownerId) {
+        List<Book> books = ownerId == null ? bookRepository.findAll() : bookRepository.findByOwnerId(ownerId);
+        return books.stream().map(DtoMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public Book getBook(Long id) {
+        return bookRepository.findById(id).orElseThrow();
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/service/DtoMapper.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/service/DtoMapper.java
@@ -1,0 +1,27 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.BookDto;
+import com.example.bookexchange.dto.TradeDto;
+import com.example.bookexchange.dto.UserDto;
+import com.example.bookexchange.model.Book;
+import com.example.bookexchange.model.Trade;
+import com.example.bookexchange.model.User;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DtoMapper {
+    public static BookDto toDto(Book book) {
+        return new BookDto(book.getId(), book.getTitle(), book.getAuthor(),
+                book.getOwner() != null ? book.getOwner().getId() : null);
+    }
+
+    public static UserDto toDto(User user) {
+        List<BookDto> books = user.getBooks().stream().map(DtoMapper::toDto).collect(Collectors.toList());
+        return new UserDto(user.getId(), user.getName(), books);
+    }
+
+    public static TradeDto toDto(Trade trade) {
+        return new TradeDto(trade.getId(), toDto(trade.getOfferedBook()), toDto(trade.getRequestedBook()), trade.getTradedAt());
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/service/TradeService.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/service/TradeService.java
@@ -1,0 +1,42 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.CreateTradeRequest;
+import com.example.bookexchange.dto.TradeDto;
+import com.example.bookexchange.model.Book;
+import com.example.bookexchange.model.Trade;
+import com.example.bookexchange.repository.TradeRepository;
+import com.example.bookexchange.model.User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class TradeService {
+    private final TradeRepository tradeRepository;
+    private final BookService bookService;
+
+    public TradeService(TradeRepository tradeRepository, BookService bookService) {
+        this.tradeRepository = tradeRepository;
+        this.bookService = bookService;
+    }
+
+    public TradeDto makeTrade(CreateTradeRequest request) {
+        Book offered = bookService.getBook(request.offeredBookId());
+        Book requested = bookService.getBook(request.requestedBookId());
+
+        User offeredOwner = offered.getOwner();
+        offered.setOwner(requested.getOwner());
+        requested.setOwner(offeredOwner);
+
+        Trade trade = new Trade(offered, requested);
+        tradeRepository.save(trade);
+        return DtoMapper.toDto(trade);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TradeDto> getTrades() {
+        return tradeRepository.findAll().stream().map(DtoMapper::toDto).toList();
+    }
+}

--- a/appBookExchange/src/main/java/com/example/bookexchange/service/UserService.java
+++ b/appBookExchange/src/main/java/com/example/bookexchange/service/UserService.java
@@ -1,0 +1,36 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.CreateUserRequest;
+import com.example.bookexchange.dto.UserDto;
+import com.example.bookexchange.model.User;
+import com.example.bookexchange.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    public UserDto createUser(CreateUserRequest request) {
+        User user = new User(request.name());
+        userRepository.save(user);
+        return DtoMapper.toDto(user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<UserDto> getUsers() {
+        return userRepository.findAll().stream().map(DtoMapper::toDto).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public User getUserById(Long id) {
+        return userRepository.findById(id).orElseThrow();
+    }
+}

--- a/appBookExchange/src/main/resources/application.properties
+++ b/appBookExchange/src/main/resources/application.properties
@@ -1,1 +1,7 @@
-spring.application.name=demo
+spring.application.name=book-exchange
+spring.jpa.hibernate.ddl-auto=update
+spring.datasource.url=jdbc:h2:mem:bookdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+springdoc.swagger-ui.path=/swagger-ui.html

--- a/appBookExchange/src/test/java/com/example/bookexchange/BookExchangeApplicationTests.java
+++ b/appBookExchange/src/test/java/com/example/bookexchange/BookExchangeApplicationTests.java
@@ -1,10 +1,10 @@
-package com.example.demo;
+package com.example.bookexchange;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class DemoApplicationTests {
+class BookExchangeApplicationTests {
 
 	@Test
 	void contextLoads() {

--- a/appBookExchange/src/test/java/com/example/bookexchange/service/BookServiceTest.java
+++ b/appBookExchange/src/test/java/com/example/bookexchange/service/BookServiceTest.java
@@ -1,0 +1,37 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.CreateBookRequest;
+import com.example.bookexchange.dto.CreateUserRequest;
+import com.example.bookexchange.dto.BookDto;
+import com.example.bookexchange.dto.UserDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class BookServiceTest {
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private BookService bookService;
+
+    private Long userId;
+
+    @BeforeEach
+    void setUp() {
+        UserDto user = userService.createUser(new CreateUserRequest("Bob"));
+        userId = user.id();
+    }
+
+    @Test
+    void addBook() {
+        BookDto dto = bookService.addBook(new CreateBookRequest("Title", "Author", userId));
+        assertThat(dto.ownerId()).isEqualTo(userId);
+        assertThat(bookService.getBooks(userId)).hasSize(1);
+    }
+}

--- a/appBookExchange/src/test/java/com/example/bookexchange/service/TradeServiceTest.java
+++ b/appBookExchange/src/test/java/com/example/bookexchange/service/TradeServiceTest.java
@@ -1,0 +1,41 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class TradeServiceTest {
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private BookService bookService;
+    @Autowired
+    private TradeService tradeService;
+
+    private Long user1Id;
+    private Long user2Id;
+    private Long book1Id;
+    private Long book2Id;
+
+    @BeforeEach
+    void setUp() {
+        user1Id = userService.createUser(new CreateUserRequest("Tom")).id();
+        user2Id = userService.createUser(new CreateUserRequest("Jerry")).id();
+        book1Id = bookService.addBook(new CreateBookRequest("Book1", "Author1", user1Id)).id();
+        book2Id = bookService.addBook(new CreateBookRequest("Book2", "Author2", user2Id)).id();
+    }
+
+    @Test
+    void tradeBooks() {
+        TradeDto trade = tradeService.makeTrade(new CreateTradeRequest(book1Id, book2Id));
+        assertThat(trade.offeredBook().ownerId()).isEqualTo(user2Id);
+        assertThat(trade.requestedBook().ownerId()).isEqualTo(user1Id);
+    }
+}

--- a/appBookExchange/src/test/java/com/example/bookexchange/service/UserServiceTest.java
+++ b/appBookExchange/src/test/java/com/example/bookexchange/service/UserServiceTest.java
@@ -1,0 +1,24 @@
+package com.example.bookexchange.service;
+
+import com.example.bookexchange.dto.CreateUserRequest;
+import com.example.bookexchange.dto.UserDto;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class UserServiceTest {
+    @Autowired
+    private UserService userService;
+
+    @Test
+    void createUser() {
+        UserDto dto = userService.createUser(new CreateUserRequest("Alice"));
+        assertThat(dto.name()).isEqualTo("Alice");
+        assertThat(userService.getUsers()).hasSize(1);
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Web, Spring Data JPA, swagger dependencies
- implement Book, User and Trade entities with JPA
- add repositories, services and controllers for CRUD and trading
- expose REST endpoints documented via Swagger UI
- add integration tests for user, book and trade flows

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_68632adbef9c8320990c663e6bd90a02